### PR TITLE
Feat allow string alongside patch data for request

### DIFF
--- a/src/schemas/word-patch-request.spec.ts
+++ b/src/schemas/word-patch-request.spec.ts
@@ -1,0 +1,174 @@
+import { expect, describe, it } from 'vitest';
+import { wordPatchRequestSchema } from './word-patch-request';
+import { z } from 'zod';
+
+describe("wordPatchRequestSchema", () => {
+   
+    it("should parse valid request using patch data", () => {
+        const validRequest = {
+            patchDocument: "doc",
+            patchData: { 
+                "test": { 
+                    type: "text", 
+                    data: "test data" 
+                } 
+            }
+        };
+
+        const parsedRequest = wordPatchRequestSchema.parse(validRequest);
+
+        expect(parsedRequest).toEqual(validRequest);
+    })
+
+    it("should parse valid request using 'text' for type property in PatchData", () => {
+        const validRequest = {
+            patchDocument: "doc",
+            patchData: { 
+                "test": { 
+                    type: "text", 
+                    data: "test data" 
+                }
+            }
+        };
+
+        const parsedRequest = wordPatchRequestSchema.parse(validRequest);
+
+        expect(parsedRequest).toEqual(validRequest);
+    })
+
+    it("should parse valid request using 'html' for type property in PatchData", () => {
+        const validRequest = {
+            patchDocument: "doc",
+            patchData: { 
+                "test": { 
+                    type: "html", 
+                    data: "test data" 
+                }
+            }
+        };
+
+        const parsedRequest = wordPatchRequestSchema.parse(validRequest);
+
+        expect(parsedRequest).toEqual(validRequest);
+    })
+
+    it("should parse valid request using valid encoded property", () => {
+        const validRequest = {
+            patchDocument: "doc",
+            patchData: { 
+                "test": { 
+                    type: "text", 
+                    encode: "b64",
+                    data: "test data" 
+                }
+            }
+        };
+
+        const parsedRequest = wordPatchRequestSchema.parse(validRequest);
+
+        expect(parsedRequest).toEqual(validRequest);
+    })
+
+    it("should parse valid request using string", () => {
+        const validRequest = {
+            patchDocument: "doc",
+            patchData: { 
+                "test": "test data"
+            }
+        };
+
+        const parsedRequest = wordPatchRequestSchema.parse(validRequest);
+
+        expect(parsedRequest).toEqual(validRequest);
+    })
+    
+    it("should throw zod error for missing patchDocument", () => {
+        const invalidRequest = {
+            patchData: { 
+                "test": "test data"
+            }
+        };
+
+        const parsedRequest = wordPatchRequestSchema.safeParse(invalidRequest);
+
+        expect(parsedRequest.success).toBe(false);;
+        if(!parsedRequest.success) {
+            expect(parsedRequest.error).toBeInstanceOf(z.ZodError);
+            expect(parsedRequest.error?.errors[0].message).toBe("required for word patcher");
+        }
+    })
+
+    it("should throw zod error for invalid patch data record value type", () => {
+        const invalidRequest = {
+            patchDocument: "doc",
+            patchData: { 
+                "test": 23
+            }
+        };
+
+        const parsedRequest = wordPatchRequestSchema.safeParse(invalidRequest);
+
+        expect(parsedRequest.success).toBe(false);;
+        if(!parsedRequest.success) {
+            expect(parsedRequest.error).toBeInstanceOf(z.ZodError);
+            expect(parsedRequest.error?.errors[0].message).toBe("Invalid input");
+        }
+    })
+
+    it("should throw zod error for invalid patch data using none record type", () => {
+        const invalidRequest = {
+            patchDocument: "doc",
+            patchData: "test"
+        };
+
+        const parsedRequest = wordPatchRequestSchema.safeParse(invalidRequest);
+
+        expect(parsedRequest.success).toBe(false);;
+        if(!parsedRequest.success) {
+            expect(parsedRequest.error).toBeInstanceOf(z.ZodError);
+            expect(parsedRequest.error?.errors[0].message).toBe("Expected object, received string");
+        }
+    })
+
+    it("should throw zod error for invalid encode literal value", () => {
+        const invalidRequest = {
+            patchDocument: "doc",
+            patchData: { 
+                "test": { 
+                    type: "text", 
+                    encode: "utf-8",
+                    data: "test data" 
+                }
+            }
+        };
+
+        const parsedRequest = wordPatchRequestSchema.safeParse(invalidRequest);
+
+        expect(parsedRequest.success).toBe(false);;
+        if(!parsedRequest.success) {
+            expect(parsedRequest.error).toBeInstanceOf(z.ZodError);
+            expect(parsedRequest.error?.errors[0].message).toBe("Invalid input");
+        }
+    })
+    
+    it("should throw zod error for 'invalid' type in PatchData", () => {
+        const invalidRequest = {
+            patchDocument: "doc",
+            patchData: { 
+                "test": { 
+                    type: "invalid", 
+                    data: "test data" 
+                }
+            }
+        };
+
+        const parsedRequest = wordPatchRequestSchema.safeParse(invalidRequest);
+
+        expect(parsedRequest.success).toBe(false);;
+        if(!parsedRequest.success) {
+            expect(parsedRequest.error).toBeInstanceOf(z.ZodError);
+            expect(parsedRequest.error?.errors[0].message).toBe("Invalid input");
+        }
+    })
+
+})

--- a/src/schemas/word-patch-request.ts
+++ b/src/schemas/word-patch-request.ts
@@ -15,5 +15,5 @@ export const wordPatchRequestSchema = z.object({
             message: "required for word patcher"
         }
     ),
-    patchData: z.record(z.string(), patchDataSchema)
+    patchData: z.record(z.string(), z.union([patchDataSchema, z.string()]))
 });

--- a/src/services/doc-gen.spec.ts
+++ b/src/services/doc-gen.spec.ts
@@ -1,4 +1,4 @@
-import { ExternalHyperlink, HeadingLevel, IPatch, Paragraph, PatchType, TextRun } from "docx";
+import { HeadingLevel, IPatch, Paragraph, PatchType, TextRun } from "docx";
 import { describe, expect } from "vitest";
 import { docGenTests, htmlTests, parseElementsTests } from "../test-utilities";
 import { createList, createPatches, getParagraphChildren, htmlToWord } from "./doc-gen";
@@ -212,6 +212,17 @@ describe("#createPatches", () => {
         const expected: Record<string, IPatch> = {};
         
         expect.soft(Object.keys(patchObject).length).toBe(0);
+        expect.soft(JSON.stringify(patchObject)).toBe(JSON.stringify(expected));
+    })
+
+    docGenTests('Create patch list without using PatchData type', ({RecordStringToString}) => {
+        const patchObject: Record<string, IPatch> = createPatches(RecordStringToString);
+        const expected: Record<string, IPatch> = {
+            "Key-Text": { type: PatchType.PARAGRAPH, children: [new TextRun("String data to add to the document")] }
+        }
+
+        expect.soft(Object.keys(patchObject).length).toBe(1);
+        expect.soft(patchObject).toHaveProperty("Key-Text");
         expect.soft(JSON.stringify(patchObject)).toBe(JSON.stringify(expected));
     })
 })

--- a/src/services/doc-gen.ts
+++ b/src/services/doc-gen.ts
@@ -135,12 +135,21 @@ export const getParagraphChildren = (pNode: Element | null): RunArray => {
     return children;
 }
 
-export const createPatches = (patchData: Record<string, PatchData>): Record<string, IPatch> => {
+export const createPatches = (patchData: Record<string, PatchData | string>): Record<string, IPatch> => {
     let patches: Record<string, IPatch> = {};
 
     for (const [key, data] of Object.entries(patchData)) {
-        const dataValue: string = data?.encoding === 'b64' ? Buffer.from(data.data, "base64").toString() : data.data;
-        switch (data.type) {
+        let dataValue: string = ""; 
+        let dataType: string = "";
+        if (typeof data === 'string') {
+            dataValue = data;
+            dataType = "text";
+        } else {
+            dataValue = data?.encoding === 'b64' ? Buffer.from(data.data, "base64").toString() : data.data;
+            dataType = data.type ?? "text";
+        }
+        
+        switch (dataType) {
             case "html":
                 patches[key] = {
                     type: PatchType.DOCUMENT,

--- a/src/test-utilities/html-tester.ts
+++ b/src/test-utilities/html-tester.ts
@@ -108,6 +108,7 @@ interface DocGenFixtures {
     PatchDataSingleItemHtmlNoEncoding: Record<string, PatchData>,
     PatchDataSingleItemHtmlB64: Record<string, PatchData>,
     PatchDataSingleItemUnsupportedType: Record<string, PatchData>,
+    RecordStringToString: Record<string, string>
 }
 
 export const docGenTests = base.extend<DocGenFixtures>({
@@ -115,6 +116,7 @@ export const docGenTests = base.extend<DocGenFixtures>({
     PatchDataSingleItemTextB64: { "encoded-text": { type: "text", data: "SGVsbG8h", encoding: "b64" } },
     PatchDataSingleItemHtmlNoEncoding: { "unencoded-html": { type: "html", data: "<p>Hello!</p>" } },
     PatchDataSingleItemHtmlB64: { "encoded-html": { type: "html", data: "PHA-SGVsbG8hPC9wPg", encoding: "b64" } },
+    RecordStringToString: { "Key-Text": "String data to add to the document" },
     // @ts-expect-error
     PatchDataSingleItemUnsupportedType: { "encoded-html": { type: "", data: "PHA-SGVsbG8hPC9wPg", encoding: "b64" } }
 }) 

--- a/src/types/request-types.ts
+++ b/src/types/request-types.ts
@@ -6,5 +6,5 @@ export type PatchData = {
 
 export type PatchRequest = {
     patchDocument: string,
-    patchData: Record<string, PatchData>
+    patchData: Record<string, PatchData | string>
 }


### PR DESCRIPTION
* Newly created service layer test to handle the specific Record<string, string> request type added and passed by new implementation.
* All previous tests still pass with no changes made to them ensuring no breaking changes.

closes #2 